### PR TITLE
Change the default ClientType to WebClient

### DIFF
--- a/httpexchange-spring-boot-autoconfigure/src/main/java/io/github/danielliu1123/httpexchange/HttpExchangeProperties.java
+++ b/httpexchange-spring-boot-autoconfigure/src/main/java/io/github/danielliu1123/httpexchange/HttpExchangeProperties.java
@@ -73,14 +73,14 @@ public class HttpExchangeProperties implements InitializingBean {
      */
     private Refresh refresh = new Refresh();
     /**
-     * Client type, default {@link ClientType#REST_CLIENT}.
+     * Client type, default {@link ClientType#WEB_CLIENT}.
      *
      * <p color="orange"> NOTE: the {@link #connectTimeout} and {@link #readTimeout} settings are not supported by {@link ClientType#WEB_CLIENT}.
      *
      * @see ClientType
      * @since 3.2.0
      */
-    private ClientType clientType = ClientType.REST_CLIENT;
+    private ClientType clientType = ClientType.WEB_CLIENT;
     /**
      * whether to process {@link org.springframework.web.bind.annotation.RequestMapping} based annotation,
      * default {@code false}.


### PR DESCRIPTION
* https://github.com/DanielLiu1123/httpexchange-spring-boot-starter/issues/33

WebClient supports both classic and reactive streams.

---

cf) https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-http-interface-return-values

---

Or we can provide DYNAMIC. (explicitly)
This provides RestClient if WebClient is not present.